### PR TITLE
Add filter function param to directive to filter files before reading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ export class MyComponent {
   ngxFilePicker
   accept="*"
   multiple
-  (filter)="filterFileBeforeReading"
+  [filter]="filterFileBeforeReading"
   (filePick)="file = $event">
   Browse
 </button>

--- a/README.md
+++ b/README.md
@@ -105,6 +105,32 @@ There are two more events that can be listened to:
 
 These two events emit the number of file (`$event` variable) to be or that has been read.
 
+In some cases you may want to filter files before reading them. You could use a special input argument `filter` which takes a function which should return `true` file to be read or `false` to stop reading.
+
+```
+export class MyComponent {
+  ...
+
+  filterFileBeforeReading(file) {
+    // file is a native browser File
+    // skip files which are >25mb
+    return file.size < 25 * 1000 * 1000;
+  }
+}
+```
+
+```
+<button
+  type="button"
+  ngxFilePicker
+  accept="*"
+  multiple
+  (filter)="filterFileBeforeReading"
+  (filePick)="file = $event">
+  Browse
+</button>
+```
+
 ## File Dropzone
 
 Add the file dropzone directive to an element, like a div.

--- a/src/file-picker.directive.ts
+++ b/src/file-picker.directive.ts
@@ -29,6 +29,8 @@ export class FilePickerDirective implements OnInit {
 
   @Input('ngxFilePicker') readMode: ReadMode;
 
+  @Input() filter: (file) => boolean = () => true;
+
   @Output() public filePick = new EventEmitter<ReadFile>();
 
   @Output() public readStart = new EventEmitter<number>();
@@ -53,11 +55,13 @@ export class FilePickerDirective implements OnInit {
     }
 
     this.renderer.listen(this.input, 'change', (event: any) => {
-      const fileCount = event.target.files.length;
+      const files = Array.from<File>(event.target.files).filter(this.filter);
+      const fileCount = files.length;
 
-      this.readStart.emit(event.target.files.length);
+      this.readStart.emit(fileCount);
       Promise.all(
-        Array.from<File>(event.target.files).map(file => this.readFile(file))
+        files
+        .map(file => this.readFile(file))
       ).then(() => this.readEnd.emit(fileCount));
     });
   }


### PR DESCRIPTION
Hello
In our app, user is allowed to upload up to 25 mb. In current implementation, there is no way to forbid user from picking 10gb file. Even more, if the user picks very big file, it starts reading it right away, which hangs browser on slow/low memory machines.
My fix adds another input parameter to filter files before starting reading them. In most cases you probably will want to filter by mimetype, extension or size.