### PR TITLE
File with same name not triggering change event on file picked

### DIFF
--- a/projects/ngx-file-helpers/src/lib/file-picker.directive.ts
+++ b/projects/ngx-file-helpers/src/lib/file-picker.directive.ts
@@ -83,6 +83,9 @@ export class FilePickerDirective extends FileHandler implements OnInit {
   private _onListen(event: Event) {
     const target = event.target as HTMLInputElement;
 
-    this.readFiles(target.files, readFile => this.filePick.emit(readFile));
+    this
+      .readFiles(target.files, readFile => this.filePick.emit(readFile))
+      // reset value to trick change event making it changeable every time
+      .finally(() => target.value = '');
   }
 }


### PR DESCRIPTION
- **Package Name**: ngx-file-helpers
- **Package Version**: 2.0.0

**Describe the bug**
When I pick a file. Then I do whatever I want. Then I want to pick a file with the same name and change event is not triggered.

**To Reproduce**
Steps to reproduce the behavior:
1. Click on browsing button (with `ngxFilePicker`)
1. Select a file `a.extension`
1. Do whatever your want with your file
1. Try to select `a.extension` (same file or file with same name). `filePick` event is not triggered.

**Expected behavior**
Input change need to trigger `filePick` everytime.