### PR TITLE
Fix missing this context in the filter callback. Closes #48

### DIFF
--- a/projects/ngx-file-helpers/src/lib/file-handler.ts
+++ b/projects/ngx-file-helpers/src/lib/file-handler.ts
@@ -25,7 +25,7 @@ export abstract class FileHandler {
     files: FileList,
     onFileRead: (fileRead: ReadFile) => void
   ): Promise<void> {
-    const filteredFiles = Array.from<File>(files).filter(this.filter);
+    const filteredFiles = Array.from<File>(files).filter((file, index, array) => this.filter(file, index, array));
     const fileCount = filteredFiles.length;
 
     this.readStart.emit(fileCount);


### PR DESCRIPTION
Fix for #48 