### PR TITLE
chore: run build before serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
+    "prestart": "npm run build:lib",
     "start": "ng serve",
     "start:lib": "ng build ngx-file-helpers --watch",
     "build": "ng build",


### PR DESCRIPTION
I wanted to test this project before installing. I stumbled a bit before realizing that the library needed to be built before the sample project could be run. This change will run `npm run build:lib` before `ng serve` so that the next person trying this project doesn't get stuck.